### PR TITLE
Bug/svg issue

### DIFF
--- a/src/QrCodeGenerator.cpp
+++ b/src/QrCodeGenerator.cpp
@@ -126,10 +126,9 @@ QString QrCodeGenerator::toSvgString(const qrcodegen::QrCode &qr,
 //   return image;
 // }
 
-
-// QR code image is being rendered from SVG output, not directly from bitmaps or matrices
-// QSvgRenderer has internal limits on path complexity or buffer size — hitting
-// those leads to the truncation warning.
+// QR code image is being rendered from SVG output, not directly from bitmaps or
+// matrices QSvgRenderer has internal limits on path complexity or buffer size —
+// hitting those leads to the truncation warning.
 //  If the generated SVG string is too large or malformed, the QSvgRenderer will
 //  throw warnings.
 // like:  W : qt.svg: Invalid path data; path truncated.
@@ -137,23 +136,28 @@ QImage QrCodeGenerator::qrCodeToImage(const qrcodegen::QrCode &qrCode,
                                       quint16 border, quint16 size) const
 {
   const int qrSize = qrCode.getSize();
-  const int scale = size / (qrSize + 2 * border);
-
-  QImage image(size, size, QImage::Format_RGB32);
+  const int totalSize = qrSize + 2 * border;
+  // Calculate scaling factor to fit requested size
+  const int pixelSize = size / totalSize;
+  const int imageSize = pixelSize * totalSize;
+  // Create the output image
+  QImage image(imageSize, imageSize, QImage::Format_RGB32);
   image.fill(Qt::white);
 
   QPainter painter(&image);
   painter.setBrush(Qt::black);
   painter.setPen(Qt::NoPen);
 
+  // Draw each QR module (black square)
   for (int y = 0; y < qrSize; ++y)
   {
     for (int x = 0; x < qrSize; ++x)
     {
       if (qrCode.getModule(x, y))
       {
-        QRect rect((x + border) * scale, (y + border) * scale, scale, scale);
-        painter.drawRect(rect);
+        int xPos = (x + border) * pixelSize;
+        int yPos = (y + border) * pixelSize;
+        painter.drawRect(xPos, yPos, pixelSize, pixelSize);
       }
     }
   }

--- a/src/QrCodeGenerator.cpp
+++ b/src/QrCodeGenerator.cpp
@@ -126,8 +126,11 @@ QString QrCodeGenerator::toSvgString(const qrcodegen::QrCode &qr,
 //   return image;
 // }
 
-// modified version that solve large string issue.
-// W : qt.svg: Invalid path data; path truncated.
+// QR code image is being rendered from SVG output, not directly from bitmaps or
+// matrices
+//  If the generated SVG string is too large or malformed, the QSvgRenderer will
+//  throw warnings.
+// like:  W : qt.svg: Invalid path data; path truncated.
 QImage QrCodeGenerator::qrCodeToImage(const qrcodegen::QrCode &qrCode,
                                       quint16 border, quint16 size) const
 {

--- a/src/QrCodeGenerator.cpp
+++ b/src/QrCodeGenerator.cpp
@@ -126,8 +126,10 @@ QString QrCodeGenerator::toSvgString(const qrcodegen::QrCode &qr,
 //   return image;
 // }
 
-// QR code image is being rendered from SVG output, not directly from bitmaps or
-// matrices
+
+// QR code image is being rendered from SVG output, not directly from bitmaps or matrices
+// QSvgRenderer has internal limits on path complexity or buffer size — hitting
+// those leads to the truncation warning.
 //  If the generated SVG string is too large or malformed, the QSvgRenderer will
 //  throw warnings.
 // like:  W : qt.svg: Invalid path data; path truncated.

--- a/src/QrCodeGenerator.cpp
+++ b/src/QrCodeGenerator.cpp
@@ -113,15 +113,45 @@ QString QrCodeGenerator::toSvgString(const qrcodegen::QrCode &qr,
  * @param size The image size to generate.
  * @return QImage representing the QR code.
  */
+// QImage QrCodeGenerator::qrCodeToImage(const qrcodegen::QrCode &qrCode,
+//                                       quint16 border, quint16 size) const
+// {
+//   QString svg = toSvgString(qrCode, border);
+//   QSvgRenderer render(svg.toUtf8());
+//   QImage image(size, size, QImage::Format_Mono);
+//   image.fill(Qt::white);
+//   QPainter painter(&image);
+//   painter.setRenderHint(QPainter::Antialiasing);
+//   render.render(&painter);
+//   return image;
+// }
+
+// modified version that solve large string issue.
+// W : qt.svg: Invalid path data; path truncated.
 QImage QrCodeGenerator::qrCodeToImage(const qrcodegen::QrCode &qrCode,
                                       quint16 border, quint16 size) const
 {
-  QString svg = toSvgString(qrCode, border);
-  QSvgRenderer render(svg.toUtf8());
-  QImage image(size, size, QImage::Format_Mono);
+  const int qrSize = qrCode.getSize();
+  const int scale = size / (qrSize + 2 * border);
+
+  QImage image(size, size, QImage::Format_RGB32);
   image.fill(Qt::white);
+
   QPainter painter(&image);
-  painter.setRenderHint(QPainter::Antialiasing);
-  render.render(&painter);
+  painter.setBrush(Qt::black);
+  painter.setPen(Qt::NoPen);
+
+  for (int y = 0; y < qrSize; ++y)
+  {
+    for (int x = 0; x < qrSize; ++x)
+    {
+      if (qrCode.getModule(x, y))
+      {
+        QRect rect((x + border) * scale, (y + border) * scale, scale, scale);
+        painter.drawRect(rect);
+      }
+    }
+  }
+
   return image;
 }


### PR DESCRIPTION
currently, QR code image is being rendered from SVG output, not directly from bitmaps or matrices.
QSvgRenderer has internal limits on path complexity or buffer size — hitting those leads to the truncation warning.
If the generated SVG string is too large or malformed, the QSvgRenderer will throw warnings, and qrcode maybe not correctly generated and will be unreadable. 

Like: If  input string is very long, the resulting QR code matrix becomes huge (e.g., 177×177 for version 40), and the SVG path becomes massive
